### PR TITLE
Danger Xcode-Summary issue

### DIFF
--- a/QuickshaRe/Domain/QRPictureGenerator.swift
+++ b/QuickshaRe/Domain/QRPictureGenerator.swift
@@ -13,7 +13,7 @@ final public class QRPictureGenerator {
     
     let context = CIContext()
     
-    private let dummy :Int = 123
+    private let dummy: Int = 123
     
     public func qrPicture(for text: String) -> Picture {
         

--- a/QuickshaRe/Domain/QRPictureGenerator.swift
+++ b/QuickshaRe/Domain/QRPictureGenerator.swift
@@ -13,7 +13,11 @@ final public class QRPictureGenerator {
     
     let context = CIContext()
     
+    private let dummy :Int = 123
+    
     public func qrPicture(for text: String) -> Picture {
+        
+        let dummy = 123
         
         let ciGenerator = CIFilter.qrCodeGenerator()
         let qrCode = ciGenerator.qrCodeImage(for: text, correctionLevel: "H")!

--- a/QuickshaRe/Domain/QRPictureGenerator.swift
+++ b/QuickshaRe/Domain/QRPictureGenerator.swift
@@ -18,6 +18,7 @@ final public class QRPictureGenerator {
     public func qrPicture(for text: String) -> Picture {
         
         let dummy = 123
+        let anotherDummy = 456
         
         let ciGenerator = CIFilter.qrCodeGenerator()
         let qrCode = ciGenerator.qrCodeImage(for: text, correctionLevel: "H")!


### PR DESCRIPTION
danger-xcode_summary plugin's inline mode is not... quite inline. It can give us the info at which line in which file the warning/error comes from, but it can't leave a comment right on that line, which danger-swiftlint plugin is able to do in its inline mode.